### PR TITLE
Implement optional unique indices and other improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__
+*.egg-info
+*.pyc

--- a/CHANGES
+++ b/CHANGES
@@ -44,6 +44,9 @@ Version 3.1.0 (under development)
 - Refactored most of the code: extract inline definitions into the global scope, 
   normalize the indentation, simplify some implementations, refactored the index classes
 
+- Fixed index pollution when one of the indexes rejected an entry after it was
+  already persisted in others
+
 
 Version 3.0.2
 -------------

--- a/CHANGES
+++ b/CHANGES
@@ -38,6 +38,12 @@ Version 3.1.0 (under development)
 
 - Some improved type annotations.
 
+- Added `optional` parameter to `Table.create_index` to define unique indexes that
+  allow missing values in some objects.
+
+- Refactored most of the code: extract inline definitions into the global scope, 
+  normalize the indentation, simplify some implementations, refactored the index classes
+
 
 Version 3.0.2
 -------------

--- a/littletable.py
+++ b/littletable.py
@@ -4617,11 +4617,11 @@ class _JoinTerm:
                     other.join_type = self.join_type
 
                 return self
-            else:
-                if other.join_to is None:
-                    return self() + other
-                else:
-                    return self() + other()
+            
+            if other.join_to is None:
+                return self() + other
+            
+            return self() + other()
         raise ValueError(
             f"cannot add object of type {type(other).__name__!r} to JoinTerm"
         )

--- a/littletable.py
+++ b/littletable.py
@@ -3930,11 +3930,11 @@ class Table[TableContent]:
         return field_names
 
     def _rich_table(
-            self,
-            fields: Iterable[str | tuple[str, dict]] | None = None,
-            empty: Any = "",
-            groupby: str | None = None,
-            **kwargs
+        self,
+        fields: Iterable[str | tuple[str, dict]] | None = None,
+        empty: Any = "",
+        groupby: str | None = None,
+        **kwargs,
     ):
         from rich.table import Table as RichTable
 

--- a/littletable.py
+++ b/littletable.py
@@ -1040,7 +1040,7 @@ def _make_comparator_null(is_null: bool) -> Callable[[], Callable[[str], Callabl
 
 
 def _make_comparator2(
-        cmp_fn: Callable[[Any, Any, Any], bool]
+    cmp_fn: Callable[[Any, Any, Any], bool],
 ) -> Callable[[Any, Any], Callable[[str], Callable[[Any], bool]]]:
     """
     Internal function to help define Table.within and between

--- a/littletable.py
+++ b/littletable.py
@@ -1202,14 +1202,15 @@ class Table[TableContent]:
 
     @staticmethod
     def parse_datetime(
-            time_format: str,
-            empty: Any = '',
-            on_error: Any | None = None
+        time_format: str,
+        empty: Any = '',
+        on_error: Any | None = None,
     ) -> Callable[[str], datetime.datetime]:
-        """Convenience method to convert string data to a datetime.datetime instance,
-           given a parse string (following strptime format).
+        """
+        Convenience method to convert string data to a datetime.datetime instance,
+        given a parse string (following strptime format).
 
-           Can be used for transforming data loaded from CSV data sets.
+        Can be used for transforming data loaded from CSV data sets.
         """
 
         def _converter(s: str = "") -> Any:
@@ -1223,12 +1224,13 @@ class Table[TableContent]:
 
     @staticmethod
     def parse_date(
-            time_format: str, empty: Any = '', on_error: Any | None = None
+        time_format: str, empty: Any = '', on_error: Any | None = None,
     ) -> Callable[[str], datetime.date]:
-        """Convenience method to convert string data to a datetime.date instance,
-           given a parse string (following strptime format).
+        """
+        Convenience method to convert string data to a datetime.date instance,
+        given a parse string (following strptime format).
 
-           Can be used for transforming data loaded from CSV data sets.
+        Can be used for transforming data loaded from CSV data sets.
         """
 
         def _converter(s: str | None = None) -> Any:
@@ -1242,16 +1244,17 @@ class Table[TableContent]:
 
     @staticmethod
     def parse_timedelta(
-            time_format: str,
-            reference_time: datetime.datetime = datetime.datetime.strptime("0:00:00", "%H:%M:%S"),
-            empty: Any = '',
-            on_error: Any | None = None
+        time_format: str,
+        reference_time: datetime.datetime = datetime.datetime.strptime("0:00:00", "%H:%M:%S"),
+        empty: Any = '',
+        on_error: Any | None = None,
     ) -> Callable[[str], datetime.timedelta]:
-        """Convenience method to convert string data to a datetime.timedelta instance,
-           given a parse string (following strptime format), and optionally a
-           reference datetime.datetime.
+        """
+        Convenience method to convert string data to a datetime.timedelta instance,
+        given a parse string (following strptime format), and optionally a
+        reference datetime.datetime.
 
-           Can be used for transforming data loaded from CSV data sets.
+        Can be used for transforming data loaded from CSV data sets.
         """
 
         def _converter(s: str | None = None) -> Any:

--- a/littletable.py
+++ b/littletable.py
@@ -2235,9 +2235,9 @@ class Table[TableContent]:
         return self
 
     def select(
-            self,
-            fields: Iterable[str] | str | None = None,
-            **exprs: Callable[[TableContent], Any]
+        self,
+        fields: Iterable[str] | str | None = None,
+        **exprs: Callable[[TableContent], Any],
     ) -> Table:
         """
         Create a new table containing a subset of attributes, with optionally
@@ -2255,10 +2255,10 @@ class Table[TableContent]:
         as a source of interpolation values.  For instance, C{fullName = '%(lastName)s, %(firstName)s'}
 
         """
-        if fields is not None:
-            fields = self._parse_fields_string(fields)
-        else:
+        if fields is None:
             fields = []
+        else:
+            fields = self._parse_fields_string(fields)
 
         def _make_string_callable(expr):
             if isinstance(expr, str):
@@ -2267,8 +2267,8 @@ class Table[TableContent]:
                     if not isinstance(r, (list, tuple))
                     else expr.format(*r)
                 )
-            else:
-                return expr
+            
+            return expr
 
         exprs = {k: _make_string_callable(v) for k, v in exprs.items()}
 

--- a/littletable.py
+++ b/littletable.py
@@ -476,58 +476,42 @@ Mapping.register(_ObjIndex)
 
 
 class _UniqueObjIndex(_ObjIndex):
-    def __init__(self, attr, accept_none=False):
+    def __init__(self, attr, accept_none=False, optional=False):
         super().__init__(attr)
         self.obs_lookup: dict = {}
         self.is_unique = True
         self.accept_none = accept_none
-        self.none_values = []
+        self.optional = optional
 
     def sort(self, key, reverse: bool = False):
         pass
 
     def __setitem__(self, k, v):
-        if k is not None:
-            if k not in self.obs_lookup:
-                self.obs_lookup[k] = v
-            else:
-                raise KeyError(f"duplicate key value {k!r}")
-        else:
-            if self.accept_none:
-                self.none_values.append(v)
-            else:
+        if k is None and not self.accept_none:
+            if not self.optional:
                 raise ValueError("None is not a valid index key")
+            return  # Missing values are not indexed, but 
+        
+        if k in self.obs_lookup:
+            raise KeyError(f"duplicate key value {k!r}")
+        
+        self.obs_lookup[k] = v
 
     def __getitem__(self, k):
-        if k is not None:
             return [self.obs_lookup.get(k)] if k in self.obs_lookup else []
-        else:
-            return list(self.none_values)
 
     def __contains__(self, k):
-        if k is not None:
             return k in self.obs_lookup
-        else:
-            return self.accept_none and self.none_values
 
     def keys(self):
-        return sorted(self.obs_lookup) + ([None, ] if self.none_values else [])
+        return sorted(self.obs_lookup)
 
     def items(self):
         return ((k, [v]) for k, v in self.obs_lookup.items())
 
     def remove(self, obj):
-        if (k := getattr(obj, self.attr)) is not None:
+        k = getattr(obj, self.attr)
             self.obs_lookup.pop(k, None)
-        else:
-            try:
-                self.none_values.remove(obj)
-            except ValueError:
-                pass
-
-    def _clear(self):
-        super()._clear()
-        del self.none_values[:]
 
 
 class _ObjIndexWrapper:

--- a/littletable.py
+++ b/littletable.py
@@ -2491,7 +2491,7 @@ class Table[TableContent]:
         attrlist: Iterable[str] | str | None = None,
         auto_create_indexes: bool = True,
         **kwargs: Any,
-    ):
+    ) -> Table:
         """
         Join the objects of one table with the objects of another, based on the given
         matching attributes in the named arguments.  The attrlist specifies the attributes to

--- a/littletable.py
+++ b/littletable.py
@@ -4255,7 +4255,7 @@ Sequence.register(Table)
 
 
 # module-level convenience functions for Table.*_import() instance methods
-def _make_module_level_import_fn[TableContent](name: str) -> Callable[[Any, ...], Table[TableContent]]:
+def _make_module_level_import_fn[TableContent](name: str) -> Callable[..., Table[TableContent]]:
     table_method = getattr(Table, name)
 
     @functools.wraps(table_method)

--- a/littletable.py
+++ b/littletable.py
@@ -4049,11 +4049,11 @@ class Table[TableContent]:
             console.print(table)
 
     def as_html(
-            self,
-            fields: str | Iterable[str] = "*",
-            formats: dict[str, str] | None = None,
-            groupby: str | Iterable[str] | None = None,
-            table_properties: dict | None = None,
+        self,
+        fields: str | Iterable[str] = "*",
+        formats: dict[str, str] | None = None,
+        groupby: str | Iterable[str] | None = None,
+        table_properties: dict | None = None,
     ) -> str:
         """
         Output the table as a rudimentary HTML table.

--- a/littletable.py
+++ b/littletable.py
@@ -1065,8 +1065,8 @@ def _make_comparator2(
 
 
 def _determine_suppressed_attrs(
-        group_attrs: list[str], prev: tuple[Any, ...], curr: tuple[Any, ...],
-        _compare=lambda attr_prev_curr: attr_prev_curr[1] == attr_prev_curr[2]
+    group_attrs: list[str], prev: tuple[Any, ...], curr: tuple[Any, ...],
+    _compare=lambda attr_prev_curr: attr_prev_curr[1] == attr_prev_curr[2],
 ) -> set[str]:
     return {a for a, _, _ in itertools.takewhile(_compare, zip(group_attrs, prev, curr))}
 

--- a/littletable.py
+++ b/littletable.py
@@ -149,7 +149,7 @@ from types import SimpleNamespace
 import urllib.request
 from typing import (
     Callable, Any, TextIO, Iterable, Iterator,
-    TypeVar, Type, cast, Tuple, overload, Self
+    TypeVar, Type, cast, overload, Self
 )
 
 from rich import box
@@ -911,10 +911,10 @@ class _MultiIterator(Iterator):
             yield line.decode(encoding)
 
 
-FixedWidthParseSpec = (
-    Tuple[str, int]
-    | Tuple[str, int, int | None]
-    | Tuple[str, int, int | None, Callable[[str], Any] | None]
+type FixedWidthParseSpec = (
+    tuple[str, int]
+    | tuple[str, int, int | None]
+    | tuple[str, int, int | None, Callable[[str], Any] | None]
 )
 
 
@@ -3567,7 +3567,7 @@ class Table[TableContent]:
             self,
             keyexpr: str | Iterable[str] | Callable[[TableContent], Any],
             sort: bool = False
-    ) -> Iterable[Tuple[Any, Table[TableContent]]]:
+    ) -> Iterable[tuple[Any, Table[TableContent]]]:
         """
         Analogous to itertools.groupby, using the Table as the iterable to be
         grouped.

--- a/littletable.py
+++ b/littletable.py
@@ -421,6 +421,9 @@ def _to_json(obj, enc_cls: Type[json.JSONEncoder] | None, **kwargs: Any) -> str:
     return json.dumps(_to_dict(obj), cls=enc_cls, **kwargs)
 
 
+NO_SUCH_ATTR = object()
+
+
 class _ObjIndex:
     def __init__(self, attr: str):
         self.attr = attr
@@ -448,6 +451,10 @@ class _ObjIndex:
 
     def items(self) -> Iterable[tuple[Any, Any]]:
         return self.obs_lookup.items()
+    
+    def add(self, obj) -> None:
+        k = getattr(obj, self.attr, None)
+        self[k] = obj
 
     def remove(self, obj) -> None:
         try:
@@ -489,7 +496,7 @@ class _UniqueObjIndex(_ObjIndex):
     def __setitem__(self, k, v):
         if k is None and not self.accept_none:
             if not self.optional:
-                raise ValueError("None is not a valid index key")
+                raise ValueError(f"unique key cannot be None or blank for index {self.attr!r}", v)
             return  # Missing values are not indexed, but 
         
         if k in self.obs_lookup:
@@ -508,6 +515,22 @@ class _UniqueObjIndex(_ObjIndex):
 
     def items(self):
         return ((k, [v]) for k, v in self.obs_lookup.items())
+    
+    def add(self, obj):
+        k = getattr(obj, self.attr, NO_SUCH_ATTR)
+        
+        if k is None and not self.accept_none:
+            k = NO_SUCH_ATTR
+        
+        if k is NO_SUCH_ATTR:
+            if self.optional:
+                return
+            raise KeyError(f"Object {obj!r} missing attribute {self.attr!r} required for unique index")
+        
+        try:
+            self[k] = obj
+        except KeyError:
+            raise KeyError(f"duplicate unique key value {k!r} for index {self!r}", obj)
 
     def remove(self, obj):
         k = getattr(obj, self.attr)
@@ -1276,7 +1299,6 @@ class Table[TableContent]:
         self(table_name)
         self.obs: list[Any] = []
         self._indexes: dict[str, _ObjIndex] = {}
-        self._uniqueIndexes: list[_UniqueObjIndex] = []
         self._search_indexes: dict[str, dict[str, list]] = {}
 
         self.import_source_type: ImportSourceType | None = None
@@ -1496,7 +1518,12 @@ class Table[TableContent]:
         return ret
 
     def create_index(
-        self, attr: str, unique: bool = False, accept_none: bool = False, force: bool = False
+        self,
+        attr: str,
+        unique: bool = False,
+        accept_none: bool = False,
+        optional: bool = False,
+        force: bool = False,
     ) -> Self:
         """
         Create a new index on a given attribute.
@@ -1522,9 +1549,12 @@ class Table[TableContent]:
             expected to be unique across table entries
         @type unique: boolean
         @param accept_none: flag indicating whether None is an acceptable
-            unique key value for this attribute (always True for non-unique
-            indexes, default=False for unique indexes)
+            unique key value for this attribute (only meaningful for unique
+            indexes, default=False)
         @type accept_none: boolean
+        @param optional: flag indicating whether the indexed field may be
+            missing, or None with accept_none=True (only meaningful for
+            unique indexes, default=False)
         @param force: flag indicating whether the index should be created
             even it if already exists (default = False)
         @type force: boolean
@@ -1536,27 +1566,19 @@ class Table[TableContent]:
             raise ValueError(f"index {attr!r} already defined for table")
 
         if unique:
-            self._indexes[attr] = _UniqueObjIndex(attr, accept_none)
-            self._uniqueIndexes[:] = [
-                ind for ind in self._indexes.values() if ind.is_unique
-            ]
+            self._indexes[attr] = _UniqueObjIndex(attr, accept_none, optional)
         else:
             self._indexes[attr] = _ObjIndex(attr)
-            accept_none = True
         ind = self._indexes[attr]
 
         try:
             for obj in self.obs:
-                obval = getattr(obj, attr, None)
-                if obval is not None or accept_none:
-                    ind[obval] = obj
-                else:
-                    raise KeyError("None is not an allowed key")
-            return self
-
+                ind.add(obj)
         except (KeyError, TypeError):
             self.drop_index(attr)
             raise
+        
+        return self
 
     def drop_index(self, attr: str) -> Self:
         """
@@ -1567,9 +1589,6 @@ class Table[TableContent]:
         """
         if attr in self._indexes:
             del self._indexes[attr]
-            self._uniqueIndexes = [
-                ind for ind in self._indexes.values() if ind.is_unique
-            ]
         return self
 
     delete_index = drop_index
@@ -1947,9 +1966,6 @@ class Table[TableContent]:
 
     def insert_many(self, it: Iterable[TableContent]) -> Self:
         """Inserts a collection of objects into the table."""
-        unique_indexes = self._uniqueIndexes
-        NO_SUCH_ATTR = object()
-
         new_objs = it
         new_objs, first_obj = itertools.tee(new_objs)
         try:
@@ -1961,42 +1977,11 @@ class Table[TableContent]:
             # iterator is empty, nothing to insert
             return self
 
-        if unique_indexes:
-            new_objs = list(new_objs)
-            for ind in unique_indexes:
-                ind_attr = ind.attr
-                new_keys = {
-                    getattr(obj, ind_attr, NO_SUCH_ATTR): obj for obj in new_objs
-                }
-                if not ind.accept_none and (
-                    None in new_keys or NO_SUCH_ATTR in new_keys
-                ):
-                    raise KeyError(
-                        f"unique key cannot be None or blank for index {ind_attr!r}",
-                        [
-                            ob
-                            for ob in new_objs
-                            if getattr(ob, ind_attr, NO_SUCH_ATTR) is None
-                        ],
-                    )
-                if len(new_keys) < len(new_objs):
-                    raise KeyError(
-                        f"given sequence contains duplicate keys for index {ind_attr!r}"
-                    )
-                for key in new_keys:
-                    if key in ind:
-                        obj = new_keys[key]
-                        raise KeyError(
-                            f"duplicate unique key value {getattr(obj, ind_attr)!r} for index {ind_attr!r}",
-                            new_keys[key],
-                        )
-
         if self._indexes:
             for obj in new_objs:
                 self.obs.append(obj)
-                for attr, ind in self._indexes.items():
-                    obval = getattr(obj, attr, None)
-                    ind[obval] = obj
+                for ind in self._indexes.values():
+                    ind.add(obj)
         else:
             self.obs.extend(new_objs)
 
@@ -2110,7 +2095,6 @@ class Table[TableContent]:
                 kwargs_list.sort(key=self._query_attr_sort_fn)
 
             ret = self
-            NO_SUCH_ATTR = object()
             for k, v in kwargs_list:
                 if callable(v):
                     if getattr(v, "is_comparator", False):
@@ -3782,13 +3766,12 @@ class Table[TableContent]:
         Quick method to list informative table statistics
         :return: dict listing table information and statistics
         """
-        unique_indexes = set(self._uniqueIndexes)
         return {
             "len": len(self),
             "name": self.table_name,
             "fields": self._attr_names(),
             "indexes": [
-                (idx_name, self._indexes[idx_name] in unique_indexes)
+                (idx_name, self._indexes[idx_name].is_unique)
                 for idx_name in self._indexes
             ],
             "created": self.create_time,

--- a/littletable.py
+++ b/littletable.py
@@ -4451,38 +4451,24 @@ class _PivotTable(Table):
 
         for attr in self._pivot_attrs:
             ret.create_index(attr)
-        if len(self._pivot_attrs) == 1:
-            for sub in self.subtables:
-                subattr, subval = sub._attr_path[-1]
-                attrdict = {subattr: subval}
-                if col is None or fn is len:
-                    attrdict[col_label] = fn(sub)
-                else:
-                    attrdict[col_label] = fn([getattr(s, col, None) for s in sub])
-                ret.insert(default_row_class(**attrdict))
-        elif len(self._pivot_attrs) == 2:
-            for sub in self.subtables:
-                for ssub in sub.subtables:
-                    attrdict = dict(ssub._attr_path)
-                    if col is None or fn is len:
-                        attrdict[col_label] = fn(ssub)
-                    else:
-                        attrdict[col_label] = fn([getattr(s, col, None) for s in ssub])
-                    ret.insert(default_row_class(**attrdict))
-        elif len(self._pivot_attrs) == 3:
-            for sub in self.subtables:
-                for ssub in sub.subtables:
-                    for sssub in ssub.subtables:
-                        attrdict = dict(sssub._attr_path)
-                        if col is None or fn is len:
-                            attrdict[col_label] = fn(sssub)
-                        else:
-                            attrdict[col_label] = fn(
-                                [getattr(s, col, None) for s in sssub]
-                            )
-                        ret.insert(default_row_class(**attrdict))
-        else:
+        
+        if len(self._pivot_attrs) > 3:
             raise ValueError("can only dump summary counts for 1 or 2-attribute pivots")
+        
+        def walk(root: _PivotTable, depth: int) -> Iterable[_PivotTable]:
+            items = [root]
+            for _ in range(depth):
+                items = itertools.chain.from_iterable(s.subtables for s in items)
+            return items
+        
+        for sub in walk(self, len(self._pivot_attrs)):
+            attrdict = dict(sub._attr_path)
+            if col is None or fn is len:
+                attrdict[col_label] = fn(sub)
+            else:
+                attrdict[col_label] = fn([getattr(s, col, None) for s in sub])
+            ret.insert(default_row_class(**attrdict))
+        
         return ret
 
     summary_counts = as_table

--- a/littletable.py
+++ b/littletable.py
@@ -755,16 +755,12 @@ class _MultiIterator(Iterator):
     """
 
     def __init__(
-            self,
-            seqobj: _ImportExportDataContainer,
-            encoding: str = "utf-8",
-            url_args: dict | None = None,
-            misc_args: dict | None = None,
+        self,
+        seqobj: _ImportExportDataContainer,
+        encoding: str = "utf-8",
+        url_args: dict | None = None,
+        misc_args: dict | None = None,
     ):
-        def _decoder(seq: Iterable[bytes]) -> Iterable[str]:
-            for line in seq:
-                yield line.decode(encoding)
-
         self.type = None
         if isinstance(seqobj, Path):
             seqobj = str(seqobj)
@@ -820,7 +816,7 @@ class _MultiIterator(Iterator):
                 # unexpected scheme - scheme is verified above to recognize only "https"
                 # or "http"
                 self._closeobj = urllib.request.urlopen(data_request, **urlopen_args)  # nosec: B310
-                self._iterobj = _decoder(self._closeobj)
+                self._iterobj = self._decoder(self._closeobj, encoding)
                 self.type = ImportSourceType.url
             else:
                 seqobj_path = Path(seqobj)
@@ -839,13 +835,13 @@ class _MultiIterator(Iterator):
                             raise ValueError(
                                 f"compressed tar archive contains multiple files, none matching {inner_name}"
                             )
-                    self._iterobj = _decoder(iterobj)
+                    self._iterobj = self._decoder(iterobj, encoding)
                     self.type = ImportSourceType.tar_gzip
                 elif seqobj_path.suffix == ".gz":
                     import gzip
 
                     self._closeobj = gzip.GzipFile(filename=seqobj)
-                    self._iterobj = _decoder(self._closeobj)
+                    self._iterobj = self._decoder(self._closeobj, encoding)
                     self.type = ImportSourceType.gzip
                 elif seqobj_path.suffix in (".xz", ".lzma"):
                     import lzma
@@ -882,7 +878,7 @@ class _MultiIterator(Iterator):
                                 f"zip archive contains multiple files, none matching {inner_name}"
                             )
 
-                    self._iterobj = _decoder(self._closeobj)
+                    self._iterobj = self._decoder(self._closeobj, encoding)
                     self.type = ImportSourceType.zip
 
                 elif seqobj_path.suffix in (".xlsx", ".xlsm", ".xlst"):
@@ -908,6 +904,11 @@ class _MultiIterator(Iterator):
             self._iterobj.close()
         if self._closeobj is not None:
             self._closeobj.close()
+    
+    @staticmethod
+    def _decoder(seq: Iterable[bytes], encoding: str) -> Iterable[str]:
+        for line in seq:
+            yield line.decode(encoding)
 
 
 FixedWidthParseSpec = (

--- a/littletable.py
+++ b/littletable.py
@@ -498,10 +498,10 @@ class _UniqueObjIndex(_ObjIndex):
         self.obs_lookup[k] = v
 
     def __getitem__(self, k):
-            return [self.obs_lookup.get(k)] if k in self.obs_lookup else []
+        return [self.obs_lookup.get(k)] if k in self.obs_lookup else []
 
     def __contains__(self, k):
-            return k in self.obs_lookup
+        return k in self.obs_lookup
 
     def keys(self):
         return sorted(self.obs_lookup)
@@ -511,7 +511,7 @@ class _UniqueObjIndex(_ObjIndex):
 
     def remove(self, obj):
         k = getattr(obj, self.attr)
-            self.obs_lookup.pop(k, None)
+        self.obs_lookup.pop(k, None)
 
 
 class _ObjIndexWrapper:
@@ -526,20 +526,18 @@ class _ObjIndexWrapper:
         return getattr(self, attr)
 
     def _getitem_using_slice(self, k):
+        if k.step is not None:
+            raise ValueError("step slicing not supported")
+        
         where_selector = {
-            (False, False, False): lambda: ValueError("must specify start and/or stop values for slice"),
-            (False, True, False): lambda: Table.lt(k.stop),
-            (True, False, False): lambda: Table.ge(k.start),
-            (True, True, False): lambda: (Table.in_range(k.start, k.stop)
+            (False, False): lambda: ValueError("must specify start and/or stop values for slice"),
+            (False, True): lambda: Table.lt(k.stop),
+            (True, False): lambda: Table.ge(k.start),
+            (True, True): lambda: (Table.in_range(k.start, k.stop)
                                           if k.start < k.stop
                                           else ValueError("slice end must be greater than slice start")),
-            (False, False, True): lambda: ValueError("step slicing not supported"),
-            (True, False, True): lambda: ValueError("step slicing not supported"),
-            (False, True, True): lambda: ValueError("step slicing not supported"),
-            (True, True, True): lambda: ValueError("step slicing not supported"),
         }[k.start is not None,
-          k.stop is not None,
-          k.step is not None]()
+          k.stop is not None]()
 
         if isinstance(where_selector, Exception):
             raise where_selector

--- a/littletable.py
+++ b/littletable.py
@@ -4137,10 +4137,10 @@ class Table[TableContent]:
         return ret
 
     def as_markdown(
-            self,
-            fields: str | Iterable[str] = "*",
-            formats: dict[str, str] | None = None,
-            groupby: str | Iterable[str] | None = None,
+        self,
+        fields: str | Iterable[str] = "*",
+        formats: dict[str, str] | None = None,
+        groupby: str | Iterable[str] | None = None,
     ) -> str:
         """
         Output the table as a Markdown table.

--- a/littletable.py
+++ b/littletable.py
@@ -2096,6 +2096,8 @@ class Table[TableContent]:
 
         @return: a new Table containing the matching objects
         """
+        ret = self
+        
         if kwargs:
             # order query criteria in ascending order of number of matching items
             # for each individual given attribute; this will minimize the number
@@ -2129,8 +2131,6 @@ class Table[TableContent]:
                 ret = newret
                 if not ret:
                     break
-        else:
-            ret = self
 
         if ret and wherefn is not None:
             newret = ret.copy_template()

--- a/littletable.py
+++ b/littletable.py
@@ -530,7 +530,7 @@ class _UniqueObjIndex(_ObjIndex):
         try:
             self[k] = obj
         except KeyError:
-            raise KeyError(f"duplicate unique key value {k!r} for index {self!r}", obj)
+            raise KeyError(f"duplicate unique key value {k!r} for index {self.attr!r}", obj) from None
 
     def remove(self, obj):
         k = getattr(obj, self.attr)
@@ -1964,24 +1964,27 @@ class Table[TableContent]:
         """
         return self.insert_many([obj])
 
-    def insert_many(self, it: Iterable[TableContent]) -> Self:
+    def insert_many(self, new_objs: Iterable[TableContent]) -> Self:
         """Inserts a collection of objects into the table."""
-        new_objs = it
-        new_objs, first_obj = itertools.tee(new_objs)
-        try:
-            first = next(first_obj)
-            if isinstance(first, dict):
-                # passed in a list of dicts, save as attributed objects
-                new_objs = (self._wrap_dict(obj) for obj in new_objs)
-        except StopIteration:
-            # iterator is empty, nothing to insert
-            return self
-
+        
         if self._indexes:
             for obj in new_objs:
+                if isinstance(obj, dict):
+                    obj = self._wrap_dict(obj)
+                
+                try:
+                    for ind in self._indexes.values():
+                        ind.add(obj)
+                except:
+                    # Improvised rollback
+                    failing_ind = ind
+                    for ind in self._indexes.values():
+                        if ind is failing_ind:
+                            break
+                        ind.remove(obj)
+                    raise
+                
                 self.obs.append(obj)
-                for ind in self._indexes.values():
-                    ind.add(obj)
         else:
             self.obs.extend(new_objs)
 

--- a/littletable.py
+++ b/littletable.py
@@ -1978,26 +1978,23 @@ class Table[TableContent]:
     def insert_many(self, new_objs: Iterable[TableContent]) -> Self:
         """Inserts a collection of objects into the table."""
         
-        if self._indexes:
-            for obj in new_objs:
-                if isinstance(obj, dict):
-                    obj = self._wrap_dict(obj)
-                
-                try:
-                    for ind in self._indexes.values():
-                        ind.add(obj)
-                except:
-                    # Improvised rollback
-                    failing_ind = ind
-                    for ind in self._indexes.values():
-                        if ind is failing_ind:
-                            break
-                        ind.remove(obj)
-                    raise
-                
-                self.obs.append(obj)
-        else:
-            self.obs.extend(new_objs)
+        for obj in new_objs:
+            if isinstance(obj, dict):
+                obj = self._wrap_dict(obj)
+            
+            try:
+                for ind in self._indexes.values():
+                    ind.add(obj)
+            except:
+                # Improvised rollback
+                failing_ind = ind
+                for ind in self._indexes.values():
+                    if ind is failing_ind:
+                        break
+                    ind.remove(obj)
+                raise
+            
+            self.obs.append(obj)
 
         self._contents_changed()
         return self

--- a/littletable.py
+++ b/littletable.py
@@ -4016,12 +4016,12 @@ class Table[TableContent]:
         return rt
 
     def present(
-            self,
-            fields: Iterable[str | tuple[str, dict]] | None = None,
-            file: TextIO | None = None,
-            groupby: str | None = None,
-            width: int | None = None,
-            **kwargs: Any
+        self,
+        fields: Iterable[str | tuple[str, dict]] | None = None,
+        file: TextIO | None = None,
+        groupby: str | None = None,
+        width: int | None = None,
+        **kwargs: Any,
     ) -> None:
         """
         Print a nicely-formatted table of the records in the Table, using the `rich`

--- a/littletable.py
+++ b/littletable.py
@@ -143,7 +143,7 @@ import statistics
 import sys
 from collections import defaultdict, namedtuple, Counter
 from collections.abc import Mapping, Sequence
-from functools import partial
+from functools import partial, cmp_to_key
 from pathlib import Path
 from types import SimpleNamespace
 import urllib.request
@@ -447,6 +447,7 @@ class _ObjIndex:
         return iter(self.obs_lookup)
 
     def keys(self) -> list[Any]:
+        # TODO: Is sorting necessary? (same question as below). Discarding None might be undesirable either way.
         return sorted(filter(partial(operator.ne, None), self.obs_lookup))
 
     def items(self) -> Iterable[tuple[Any, Any]]:
@@ -511,7 +512,17 @@ class _UniqueObjIndex(_ObjIndex):
         return k in self.obs_lookup
 
     def keys(self):
-        return sorted(self.obs_lookup)
+        # The keys are not guaranteed to be comparable in the first place,
+        # and now that None is an option, this will often come up.
+        # This is a robust way to compare just about anything, but it may be meaningless semantically.
+        # TODO: Do we need to sort the keys at all? Perhaps insertion order is fine?
+        def cmp(a, b) -> int:
+            try:
+                return (a > b) - (a < b)
+            except:
+                return id(a) - id(b)
+        
+        return sorted(self.obs_lookup, key=cmp_to_key(cmp))
 
     def items(self):
         return ((k, [v]) for k, v in self.obs_lookup.items())

--- a/littletable.py
+++ b/littletable.py
@@ -944,32 +944,30 @@ class FixedWidthReader:
         src_file: str | Iterable[Any] | TextIO,
         encoding: str = "utf-8",
     ):
-        def parse_spec(
-            spec: list[Any],
-        ) -> list[tuple[str, slice, Callable[[str], Any]]]:
-            def normalize_parse_spec(ps: Any) -> Any:
-                return (*ps, None, None)[:4]  # noqa
-
-            # add a "rest of the line" spec to the parse spec to terminate
-            # the last column
-            rest_of_line_spec = ("", None)
-            spec.append(rest_of_line_spec)
-
-            ret: list[tuple[str, slice, Callable[[str], Any]]] = []
-            for cur, next_ in zip(spec, spec[1:]):
-                label, col, end_col, fn = normalize_parse_spec(cur)
-                if label is None:
-                    continue
-                if end_col is None:
-                    end_col = next_[1]
-                if fn is None:
-                    fn = str.strip
-                ret.append((label.lower(), slice(col, end_col), fn))
-            return ret
-
-        self._slices = parse_spec(slice_spec)
+        self._slices = self._parse_spec(slice_spec)
         self._src_file = src_file
         self._encoding = encoding
+    
+    @staticmethod
+    def _parse_spec(
+        spec: list[Any],
+    ) -> list[tuple[str, slice, Callable[[str], Any]]]:
+        # add a "rest of the line" spec to the parse spec to terminate
+        # the last column
+        rest_of_line_spec = ("", None)
+        spec.append(rest_of_line_spec)
+
+        ret: list[tuple[str, slice, Callable[[str], Any]]] = []
+        for cur, next_ in zip(spec, spec[1:]):
+            label, col, end_col, fn = (*cur, None, None)[:4]  # noqa
+            if label is None:
+                continue
+            if end_col is None:
+                end_col = next_[1]
+            if fn is None:
+                fn = str.strip
+            ret.append((label.lower(), slice(col, end_col), fn))
+        return ret
 
     def __iter__(self) -> Iterable[dict[str, Any]]:
         with contextlib.closing(_MultiIterator(self._src_file, self._encoding)) as _srciter:

--- a/littletable.py
+++ b/littletable.py
@@ -4488,18 +4488,18 @@ class _PivotTable(Table):
 
 class _PivotTableSummary:
     def __init__(
-            self,
-            pivot_table: _PivotTable,
-            pivot_attrs: list[str],
-            count_fn: Callable[[Iterable], int] = len,
-            col_label: str | None = None,
+        self,
+        pivot_table: _PivotTable,
+        pivot_attrs: list[str],
+        count_fn: Callable[[Iterable], int] = len,
+        col_label: str | None = None,
     ):
         self._pt = pivot_table
         self._pivot_attrs = pivot_attrs
         self._fn = count_fn
         self._label = col_label
 
-    def as_html(self, **kwargs):
+    def as_html(self, **kwargs) -> str:
         formats = kwargs.get("formats", {})
         if len(self._pivot_attrs) == 1:
             col = self._pivot_attrs[0]

--- a/littletable.py
+++ b/littletable.py
@@ -497,7 +497,7 @@ class _UniqueObjIndex(_ObjIndex):
         if k is None and not self.accept_none:
             if not self.optional:
                 raise ValueError(f"unique key cannot be None or blank for index {self.attr!r}", v)
-            return  # Missing values are not indexed, but 
+            return  # Missing values are not indexed, but simply ignored
         
         if k in self.obs_lookup:
             raise KeyError(f"duplicate key value {k!r}")

--- a/littletable.py
+++ b/littletable.py
@@ -198,6 +198,16 @@ class ReadonlyIndexAccessError(Exception):
     """
 
 
+class PathNotFoundError(KeyError):
+    def __init__(self, key, nf_path):
+        super().__init__(key)
+        self.key = key
+        self.path = nf_path
+
+    def __str__(self):
+        return f"could not find {self.key!r} element of path {self.path!r} in imported JSON"
+
+
 class AuthenticationWarning(Warning):
     """
     Warning emitted when using authentication credentials with http:// URL.
@@ -1009,6 +1019,41 @@ class FixedWidthReader:
                 if not line.strip():
                     continue
                 yield {label: fn(line[slc]) for label, slc, fn in self._slices}
+
+
+class _JsonFileReader:
+    def __init__(self, src, streaming, path, decoder):
+        self.source = src
+        self.streaming = streaming
+        self.path = path
+        self.decoder = decoder
+
+    def __iter__(self):
+        if self.streaming:
+            # incrementally read lines from source until a valid JSON object
+            # can be parsed
+            current = ""
+            for line in self.source:
+                if current:
+                    current += " "
+                current += line
+                try:
+                    yield json.loads(current, cls=self.decoder)
+                    current = ""
+                except json.JSONDecodeError:
+                    pass
+        else:
+            # merge entire source into one JSON parseable object
+            inbound_json = '\n'.join(self.source)
+            obs = json.loads(inbound_json, cls=self.decoder)
+
+            # descend into parsed JSON object by path
+            for path_item in filter(None, self.path.split(".")):
+                obs = obs.get(path_item)
+                if obs is None:
+                    raise PathNotFoundError(path_item, self.path)
+
+            yield from obs
 
 
 def _make_comparator(cmp_fn: Callable[[Any, Any], bool]) -> Callable[[Any], Callable[[Any], Callable[[Any], bool]]]:
@@ -3217,47 +3262,6 @@ class Table[TableContent]:
         @param limit: maximum number of records to import
         @type limit: int (optional)
         """
-        class PathNotFoundError(KeyError):
-            def __init__(self, key, nf_path):
-                super().__init__(key)
-                self.key = key
-                self.path = nf_path
-
-            def __str__(self):
-                return f"could not find {self.key!r} element of path {self.path!r} in imported JSON"
-
-        class _JsonFileReader:
-            def __init__(self, src):
-                self.source = src
-                self.streaming = streaming
-
-            def __iter__(self):
-                if self.streaming:
-                    # incrementally read lines from source until a valid JSON object
-                    # can be parsed
-                    current = ""
-                    for line in self.source:
-                        if current:
-                            current += " "
-                        current += line
-                        try:
-                            yield json.loads(current, cls=json_decoder)
-                            current = ""
-                        except json.JSONDecodeError:
-                            pass
-                else:
-                    # merge entire source into one JSON parseable object
-                    inbound_json = '\n'.join(self.source)
-                    obs = json.loads(inbound_json, cls=json_decoder)
-
-                    # descend into parsed JSON object by path
-                    for path_item in filter(None, path.split(".")):
-                        obs = obs.get(path_item)
-                        if obs is None:
-                            raise PathNotFoundError(path_item, path)
-
-                    yield from obs
-
         if isinstance(source, str):
             if source.endswith(".jsonl"):
                 streaming = True
@@ -3282,7 +3286,7 @@ class Table[TableContent]:
             source,
             encoding,
             transforms=transforms,
-            reader=_JsonFileReader,
+            reader=partial(_JsonFileReader, streaming=streaming, path=path, decoder=json_decoder),
             row_class=row_class,
             url_args=url_args,
             limit=limit,

--- a/littletable.py
+++ b/littletable.py
@@ -1431,12 +1431,11 @@ class Table[TableContent]:
         if isinstance(other, _JoinTerm):
             # special case if added to a JoinTerm, do join, not union
             return other + self
-        elif isinstance(other, Table):
+        if isinstance(other, Table):
             # if other is another Table, just union them
             return self.union(other)
-        else:
-            # assume other is a sequence of some sort, insert all elements
-            return self.clone().insert_many(other)
+        # assume other is a sequence of some sort, insert all elements
+        return self.clone().insert_many(other)
 
     def __iadd__(self, other: Table) -> Self:
         """Support UNION of 2 tables using "+=" operator."""

--- a/littletable.py
+++ b/littletable.py
@@ -1837,13 +1837,13 @@ class Table[TableContent]:
         return self
 
     def _search(
-            self,
-            attrname: str,
-            query: str,
-            limit: int = int(1e9),
-            min_score: int = 0,
-            include_words: bool = False,
-            as_table: bool = True
+        self,
+        attrname: str,
+        query: str,
+        limit: int = int(1e9),
+        min_score: int = 0,
+        include_words: bool = False,
+        as_table: bool = True,
     ):
         if attrname not in self._search_indexes:
             raise ValueError(f"no search index defined for attribute {attrname!r}")

--- a/littletable.py
+++ b/littletable.py
@@ -574,8 +574,9 @@ class _UniqueObjIndexWrapper(_ObjIndexWrapper):
         if isinstance(k, slice):
             return super().__getitem__(k)
         try:
-            return self._index[k][0]
-        except IndexError:
+            only_item, = self._index[k]
+            return only_item
+        except ValueError:
             raise KeyError(f"no such value {k!r} in index {self._index.attr!r}")
 
 

--- a/littletable.py
+++ b/littletable.py
@@ -695,32 +695,32 @@ class _IndexAccessor:
         If there is no index defined for the given attribute, then C{AttributeError} is raised.
         """
         attr_index = self._table._indexes.get(attr)
-        if attr_index is not None:
-            if isinstance(attr_index, _UniqueObjIndex):
-                attr_index_wrapper = _UniqueObjIndexWrapper(attr_index, self._table)
-                attr_index_wrapper.__doc__ = textwrap.dedent(
-                    f"""\
-                    Index accessor by {attr!r}
-                    
-                    tbl.by.{attr}[attr_value] returns the object having {attr}=attr_value.
-                    If no such object exists, raises KeyError.
-                    """
-                )
+        if attr_index is None:
+            raise AttributeError(f"Table {self._table.table_name!r} has no index {attr!r}")
 
-            else:
-                attr_index_wrapper = _ObjIndexWrapper(attr_index, self._table)
-                attr_index_wrapper.__doc__ = textwrap.dedent(
-                    f"""\
-                    Index accessor by {attr!r}
+        if isinstance(attr_index, _UniqueObjIndex):
+            attr_index_wrapper = _UniqueObjIndexWrapper(attr_index, self._table)
+            attr_index_wrapper.__doc__ = textwrap.dedent(
+                f"""\
+                Index accessor by {attr!r}
+                
+                tbl.by.{attr}[attr_value] returns the object having {attr}=attr_value.
+                If no such object exists, raises KeyError.
+                """
+            )
 
-                    tbl.by.{attr}[attr_value] returns a new Table of all objects having {attr}=attr_value.
-                    If no matching objects exist, returns an empty Table.
-                    """
-                )
+        else:
+            attr_index_wrapper = _ObjIndexWrapper(attr_index, self._table)
+            attr_index_wrapper.__doc__ = textwrap.dedent(
+                f"""\
+                Index accessor by {attr!r}
 
-            return attr_index_wrapper
+                tbl.by.{attr}[attr_value] returns a new Table of all objects having {attr}=attr_value.
+                If no matching objects exist, returns an empty Table.
+                """
+            )
 
-        raise AttributeError(f"Table {self._table.table_name!r} has no index {attr!r}")
+        return attr_index_wrapper
 
     def __call__(self, attr):
         return getattr(self, attr)

--- a/littletable.py
+++ b/littletable.py
@@ -3610,11 +3610,11 @@ class Table[TableContent]:
             offset += batch_size
 
     def splitby(
-            self,
-            pred: str | PredicateFunction = None,
-            *,
-            errors: bool | str | dict[type[Exception], bool | str] = "discard",
-            **kwargs,
+        self,
+        pred: str | PredicateFunction = None,
+        *,
+        errors: bool | str | dict[type[Exception], bool | str] = "discard",
+        **kwargs,
     ) -> tuple[Table[TableContent], ...]:
         """
         Takes a predicate function (takes a table record and returns True or False)
@@ -3669,12 +3669,11 @@ class Table[TableContent]:
             else:
                 key, value = next(iter(kwargs.items()))
                 pred = lambda split_rec: getattr(split_rec, key, None) == value
-        else:
-            if kwargs:
-                raise ValueError(
-                    "must provide either a predicate function or one or more named"
-                    " arguments, not both"
-                )
+        elif kwargs:
+            raise ValueError(
+                "must provide either a predicate function or one or more named"
+                " arguments, not both"
+            )
 
         # if key is a str, convert it to a predicate function using getattr
         if isinstance(pred, str):
@@ -3702,8 +3701,8 @@ class Table[TableContent]:
                 )
 
             if not all(
-                    error_response in {True, False, "return", "discard", "raise"}
-                    for error_response in errors.values()
+                error_response in {True, False, "return", "discard", "raise"}
+                for error_response in errors.values()
             ):
                 raise ValueError(
                     f"one or more error values is invalid {errors!r};"
@@ -3723,10 +3722,10 @@ class Table[TableContent]:
                 " or a dict mapping Exception types to one of those values")
 
         # wrap pred in try-except, to infer any failure of pred -> False,
-        # and use not not to bool-ify the value returned from pred()
+        # and use bool to bool-ify the value returned from pred()
         def wrapped_pred(obj):
             try:
-                return not not pred(obj)
+                return bool(pred(obj))
             except Exception as exc:
                 for exctype, retval in error_responses.items():
                     if isinstance(exc, exctype):
@@ -3738,8 +3737,8 @@ class Table[TableContent]:
         # construct return tables to receive False and True evaluated records
         ret = self.copy_template(), self.copy_template()
         if any(
-                error_response is RETURN_ERRORS_TABLE
-                for error_response in error_responses.values()
+            error_response is RETURN_ERRORS_TABLE
+            for error_response in error_responses.values()
         ):
             ret += (self.copy_template(),)
 

--- a/littletable.py
+++ b/littletable.py
@@ -1071,9 +1071,6 @@ def _determine_suppressed_attrs(
     return {a for a, _, _ in itertools.takewhile(_compare, zip(group_attrs, prev, curr))}
 
 
-TableContent = TypeVar("TableContent")
-
-
 class Table[TableContent]:
     """
     Table is the main class in C{littletable}, for representing a collection of SimpleNamespaces or
@@ -4257,7 +4254,7 @@ Sequence.register(Table)
 
 
 # module-level convenience functions for Table.*_import() instance methods
-def _make_module_level_import_fn(name: str) -> Callable[[Any, ...], Table[TableContent]]:
+def _make_module_level_import_fn[TableContent](name: str) -> Callable[[Any, ...], Table[TableContent]]:
     table_method = getattr(Table, name)
 
     @functools.wraps(table_method)

--- a/littletable.py
+++ b/littletable.py
@@ -3562,9 +3562,9 @@ class Table[TableContent]:
         return tbl
 
     def groupby(
-            self,
-            keyexpr: str | Iterable[str] | Callable[[TableContent], Any],
-            sort: bool = False
+        self,
+        keyexpr: str | Iterable[str] | Callable[[TableContent], Any],
+        sort: bool = False,
     ) -> Iterable[tuple[Any, Table[TableContent]]]:
         """
         Analogous to itertools.groupby, using the Table as the iterable to be

--- a/littletable.py
+++ b/littletable.py
@@ -1380,8 +1380,8 @@ class Table[TableContent]:
             ret = self.copy_template()
             ret.insert_many(self.obs[i])
             return ret
-        else:
-            return self.obs[i]
+        
+        return self.obs[i]
 
     def __delitem__(self, i: int | slice) -> None:
         if isinstance(i, int):

--- a/littletable.py
+++ b/littletable.py
@@ -2320,7 +2320,7 @@ class Table[TableContent]:
 
         return self.select(**select_exprs)
 
-    def format(self, fmt: str):
+    def format(self, fmt: str) -> Iterable[str]:
         """
         Generates a list of strings, one for each row in the table, using the input string
         as a format template for printing out a single row.

--- a/littletable.py
+++ b/littletable.py
@@ -1136,11 +1136,11 @@ class Table[TableContent]:
 
     @staticmethod
     def convert_numeric(
-            s: str | None = None,
-            empty: Any = '',
-            non_numeric: Type = object,
-            force_float: bool = False,
-            _int_fn: Callable[[str], int] = int,
+        s: str | None = None,
+        empty: Any = '',
+        non_numeric: Type = object,
+        force_float: bool = False,
+        _int_fn: Callable[[str], int] = int,
     ) -> Callable | Any:
         """
         Convenience method for transforming columns of CSV data from str to float and/or int. By default,
@@ -1184,8 +1184,8 @@ class Table[TableContent]:
                                non_numeric=non_numeric,
                                force_float=force_float,
                                _int_fn=(int, float)[force_float])
-            else:
-                return Table.convert_numeric
+            
+            return Table.convert_numeric
 
         if s == '':
             return empty
@@ -1193,10 +1193,12 @@ class Table[TableContent]:
         try:
             return _int_fn(s)
         except ValueError:
-            try:
-                return float(s)
-            except ValueError:
-                return s if non_numeric is object else non_numeric
+            pass
+        
+        try:
+            return float(s)
+        except ValueError:
+            return s if non_numeric is object else non_numeric
 
     @staticmethod
     def parse_datetime(

--- a/littletable.py
+++ b/littletable.py
@@ -4276,10 +4276,10 @@ class _PivotTable(Table):
     """Enhanced Table containing pivot results from calling table.pivot()."""
 
     def __init__(
-            self,
-            parent: Table | _PivotTable,
-            attr_val_path: list[tuple[str, str]],
-            attrlist: Iterable[str],
+        self,
+        parent: Table | _PivotTable,
+        attr_val_path: list[tuple[str, str]],
+        attrlist: Iterable[str],
     ):
         """PivotTable initializer - do not create these directly, use
         L{Table.pivot}.
@@ -4341,11 +4341,11 @@ class _PivotTable(Table):
         return bool(self.subtables)
 
     def dump(
-            self,
-            out: TextIO = sys.stdout,
-            row_fn: Callable[[Any], str] = repr,
-            limit: int = -1,
-            indent: int = 0,
+        self,
+        out: TextIO = sys.stdout,
+        row_fn: Callable[[Any], str] = repr,
+        limit: int = -1,
+        indent: int = 0,
     ) -> None:
         """
         Dump out the contents of this table in a nested listing.
@@ -4373,10 +4373,10 @@ class _PivotTable(Table):
         out.flush()
 
     def dump_counts(
-            self,
-            out: TextIO = sys.stdout,
-            count_fn: Callable[[Iterable[Any]], int] = len,
-            colwidth: int = 10
+        self,
+        out: TextIO = sys.stdout,
+        count_fn: Callable[[Iterable[Any]], int] = len,
+        colwidth: int = 10,
     ) -> None:
         """
         Dump out the summary counts of entries in this pivot table as a tabular listing.
@@ -4434,10 +4434,10 @@ class _PivotTable(Table):
             raise ValueError("can only dump summary counts for 1 or 2-attribute pivots")
 
     def as_table(
-            self,
-            fn: Callable | None = None,
-            col: str | None = None,
-            col_label: str | None = None,
+        self,
+        fn: Callable | None = None,
+        col: str | None = None,
+        col_label: str | None = None,
     ) -> Table:
         """Dump out the summary counts of this pivot table as a Table."""
         if col_label is None:
@@ -4488,9 +4488,9 @@ class _PivotTable(Table):
     summary_counts = as_table
 
     def summarize(
-            self,
-            count_fn: Callable[[Iterable], int] = len,
-            col_label: str | None = None,
+        self,
+        count_fn: Callable[[Iterable], int] = len,
+        col_label: str | None = None,
     ) -> _PivotTableSummary:
         if col_label is None:
             if len(self._pivot_attrs) == 1:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12"
 license = "MIT"
 authors = [
-  { name = "Paul McGuire", email = "ptmcg@austin.rr.com" }
+  { name = "Paul McGuire", email = "ptmcg@austin.rr.com" },
+  { name = "abel1502" }
 ]
 maintainers = [
   { name = "Paul McGuire", email = "ptmcg@austin.rr.com" }


### PR DESCRIPTION
My implementation for #8, as well as other associated improvements and fixes.

One point where I'd like to get some input is, in `_ObjIndex.keys()` and `_UniqueObjIndex.keys()`, is the natural sorting necessary? The keys are not necessarily comparable in any meaningful way (Python's `dict` is a hashmap, not a search tree), and if the only goal is a stable order, the insertion order (maintained by `dict` since Python 3.6) should be just as good but a lot cheaper performance-wise.

I also got the impression after looking at the code that the full-text search is somewhat superfluous here. I think it might be better to provide a generic system for cacheable search in its place. The specific implementation of fuzzy text search could then be delegated to a dedicated third-party library. But it would be very rude of me to remove parts of someone else's project, and definitely far outside the scope of this PR, so I'm just floating the suggestion here, before I forget.