### PR TITLE
Optional unique index v2: electric boogaloo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__
+*.egg-info
+*.pyc

--- a/littletable.py
+++ b/littletable.py
@@ -476,58 +476,42 @@ Mapping.register(_ObjIndex)
 
 
 class _UniqueObjIndex(_ObjIndex):
-    def __init__(self, attr, accept_none=False):
+    def __init__(self, attr, accept_none=False, optional=False):
         super().__init__(attr)
         self.obs_lookup: dict = {}
         self.is_unique = True
         self.accept_none = accept_none
-        self.none_values = []
+        self.optional = optional
 
     def sort(self, key, reverse: bool = False):
         pass
 
     def __setitem__(self, k, v):
-        if k is not None:
-            if k not in self.obs_lookup:
-                self.obs_lookup[k] = v
-            else:
-                raise KeyError(f"duplicate key value {k!r}")
-        else:
-            if self.accept_none:
-                self.none_values.append(v)
-            else:
+        if k is None and not self.accept_none:
+            if not self.optional:
                 raise ValueError("None is not a valid index key")
+            return  # Missing values are not indexed, but 
+        
+        if k in self.obs_lookup:
+            raise KeyError(f"duplicate key value {k!r}")
+        
+        self.obs_lookup[k] = v
 
     def __getitem__(self, k):
-        if k is not None:
             return [self.obs_lookup.get(k)] if k in self.obs_lookup else []
-        else:
-            return list(self.none_values)
 
     def __contains__(self, k):
-        if k is not None:
             return k in self.obs_lookup
-        else:
-            return self.accept_none and self.none_values
 
     def keys(self):
-        return sorted(self.obs_lookup) + ([None, ] if self.none_values else [])
+        return sorted(self.obs_lookup)
 
     def items(self):
         return ((k, [v]) for k, v in self.obs_lookup.items())
 
     def remove(self, obj):
-        if (k := getattr(obj, self.attr)) is not None:
+        k = getattr(obj, self.attr)
             self.obs_lookup.pop(k, None)
-        else:
-            try:
-                self.none_values.remove(obj)
-            except ValueError:
-                pass
-
-    def _clear(self):
-        super()._clear()
-        del self.none_values[:]
 
 
 class _ObjIndexWrapper:

--- a/littletable.py
+++ b/littletable.py
@@ -143,7 +143,7 @@ import statistics
 import sys
 from collections import defaultdict, namedtuple, Counter
 from collections.abc import Mapping, Sequence
-from functools import partial
+from functools import partial, cmp_to_key
 from pathlib import Path
 from types import SimpleNamespace
 import urllib.request
@@ -447,6 +447,7 @@ class _ObjIndex:
         return iter(self.obs_lookup)
 
     def keys(self) -> list[Any]:
+        # TODO: Is sorting necessary? (same question as below). Discarding None might be undesirable either way.
         return sorted(filter(partial(operator.ne, None), self.obs_lookup))
 
     def items(self) -> Iterable[tuple[Any, Any]]:
@@ -511,7 +512,17 @@ class _UniqueObjIndex(_ObjIndex):
             return k in self.obs_lookup
 
     def keys(self):
-        return sorted(self.obs_lookup)
+        # The keys are not guaranteed to be comparable in the first place,
+        # and now that None is an option, this will often come up.
+        # This is a robust way to compare just about anything, but it may be meaningless semantically.
+        # TODO: Do we need to sort the keys at all? Perhaps insertion order is fine?
+        def cmp(a, b) -> int:
+            try:
+                return (a > b) - (a < b)
+            except:
+                return id(a) - id(b)
+        
+        return sorted(self.obs_lookup, key=cmp_to_key(cmp))
 
     def items(self):
         return ((k, [v]) for k, v in self.obs_lookup.items())

--- a/littletable.py
+++ b/littletable.py
@@ -545,7 +545,7 @@ class _UniqueObjIndex(_ObjIndex):
 
     def remove(self, obj):
         k = getattr(obj, self.attr)
-            self.obs_lookup.pop(k, None)
+        self.obs_lookup.pop(k, None)
 
 
 class _ObjIndexWrapper:

--- a/littletable.py
+++ b/littletable.py
@@ -1073,9 +1073,6 @@ def _determine_suppressed_attrs(
     return {a for a, _, _ in itertools.takewhile(_compare, zip(group_attrs, prev, curr))}
 
 
-TableContent = TypeVar("TableContent")
-
-
 class Table[TableContent]:
     """
     Table is the main class in C{littletable}, for representing a collection of SimpleNamespaces or
@@ -4259,7 +4256,7 @@ Sequence.register(Table)
 
 
 # module-level convenience functions for Table.*_import() instance methods
-def _make_module_level_import_fn(name: str) -> Callable[[Any, ...], Table[TableContent]]:
+def _make_module_level_import_fn[TableContent](name: str) -> Callable[[Any, ...], Table[TableContent]]:
     table_method = getattr(Table, name)
 
     @functools.wraps(table_method)

--- a/littletable.py
+++ b/littletable.py
@@ -497,7 +497,7 @@ class _UniqueObjIndex(_ObjIndex):
         if k is None and not self.accept_none:
             if not self.optional:
                 raise ValueError(f"unique key cannot be None or blank for index {self.attr!r}", v)
-            return  # Missing values are not indexed, but 
+            return  # Missing values are not indexed, but simply ignored
         
         if k in self.obs_lookup:
             raise KeyError(f"duplicate key value {k!r}")

--- a/littletable.py
+++ b/littletable.py
@@ -421,6 +421,9 @@ def _to_json(obj, enc_cls: Type[json.JSONEncoder] | None, **kwargs: Any) -> str:
     return json.dumps(_to_dict(obj), cls=enc_cls, **kwargs)
 
 
+NO_SUCH_ATTR = object()
+
+
 class _ObjIndex:
     def __init__(self, attr: str):
         self.attr = attr
@@ -448,6 +451,10 @@ class _ObjIndex:
 
     def items(self) -> Iterable[tuple[Any, Any]]:
         return self.obs_lookup.items()
+    
+    def add(self, obj) -> None:
+        k = getattr(obj, self.attr, None)
+        self[k] = obj
 
     def remove(self, obj) -> None:
         try:
@@ -489,7 +496,7 @@ class _UniqueObjIndex(_ObjIndex):
     def __setitem__(self, k, v):
         if k is None and not self.accept_none:
             if not self.optional:
-                raise ValueError("None is not a valid index key")
+                raise ValueError(f"unique key cannot be None or blank for index {self.attr!r}", v)
             return  # Missing values are not indexed, but 
         
         if k in self.obs_lookup:
@@ -508,6 +515,22 @@ class _UniqueObjIndex(_ObjIndex):
 
     def items(self):
         return ((k, [v]) for k, v in self.obs_lookup.items())
+    
+    def add(self, obj):
+        k = getattr(obj, self.attr, NO_SUCH_ATTR)
+        
+        if k is None and not self.accept_none:
+            k = NO_SUCH_ATTR
+        
+        if k is NO_SUCH_ATTR:
+            if self.optional:
+                return
+            raise KeyError(f"Object {obj!r} missing attribute {self.attr!r} required for unique index")
+        
+        try:
+            self[k] = obj
+        except KeyError:
+            raise KeyError(f"duplicate unique key value {k!r} for index {self!r}", obj)
 
     def remove(self, obj):
         k = getattr(obj, self.attr)
@@ -1273,7 +1296,6 @@ class Table[TableContent]:
         self(table_name)
         self.obs: list[Any] = []
         self._indexes: dict[str, _ObjIndex] = {}
-        self._uniqueIndexes: list[_UniqueObjIndex] = []
         self._search_indexes: dict[str, dict[str, list]] = {}
 
         self.import_source_type: ImportSourceType | None = None
@@ -1494,7 +1516,12 @@ class Table[TableContent]:
         return ret
 
     def create_index(
-        self, attr: str, unique: bool = False, accept_none: bool = False, force: bool = False
+        self,
+        attr: str,
+        unique: bool = False,
+        accept_none: bool = False,
+        optional: bool = False,
+        force: bool = False,
     ) -> Self:
         """
         Create a new index on a given attribute.
@@ -1520,9 +1547,12 @@ class Table[TableContent]:
             expected to be unique across table entries
         @type unique: boolean
         @param accept_none: flag indicating whether None is an acceptable
-            unique key value for this attribute (always True for non-unique
-            indexes, default=False for unique indexes)
+            unique key value for this attribute (only meaningful for unique
+            indexes, default=False)
         @type accept_none: boolean
+        @param optional: flag indicating whether the indexed field may be
+            missing, or None with accept_none=True (only meaningful for
+            unique indexes, default=False)
         @param force: flag indicating whether the index should be created
             even it if already exists (default = False)
         @type force: boolean
@@ -1534,27 +1564,19 @@ class Table[TableContent]:
             raise ValueError(f"index {attr!r} already defined for table")
 
         if unique:
-            self._indexes[attr] = _UniqueObjIndex(attr, accept_none)
-            self._uniqueIndexes[:] = [
-                ind for ind in self._indexes.values() if ind.is_unique
-            ]
+            self._indexes[attr] = _UniqueObjIndex(attr, accept_none, optional)
         else:
             self._indexes[attr] = _ObjIndex(attr)
-            accept_none = True
         ind = self._indexes[attr]
 
         try:
             for obj in self.obs:
-                obval = getattr(obj, attr, None)
-                if obval is not None or accept_none:
-                    ind[obval] = obj
-                else:
-                    raise KeyError("None is not an allowed key")
-            return self
-
+                ind.add(obj)
         except (KeyError, TypeError):
             self.drop_index(attr)
             raise
+        
+        return self
 
     def drop_index(self, attr: str) -> Self:
         """
@@ -1565,9 +1587,6 @@ class Table[TableContent]:
         """
         if attr in self._indexes:
             del self._indexes[attr]
-            self._uniqueIndexes = [
-                ind for ind in self._indexes.values() if ind.is_unique
-            ]
         return self
 
     delete_index = drop_index
@@ -1945,9 +1964,6 @@ class Table[TableContent]:
 
     def insert_many(self, it: Iterable[TableContent]) -> Self:
         """Inserts a collection of objects into the table."""
-        unique_indexes = self._uniqueIndexes
-        NO_SUCH_ATTR = object()
-
         new_objs = it
         new_objs, first_obj = itertools.tee(new_objs)
         try:
@@ -1959,42 +1975,11 @@ class Table[TableContent]:
             # iterator is empty, nothing to insert
             return self
 
-        if unique_indexes:
-            new_objs = list(new_objs)
-            for ind in unique_indexes:
-                ind_attr = ind.attr
-                new_keys = {
-                    getattr(obj, ind_attr, NO_SUCH_ATTR): obj for obj in new_objs
-                }
-                if not ind.accept_none and (
-                    None in new_keys or NO_SUCH_ATTR in new_keys
-                ):
-                    raise KeyError(
-                        f"unique key cannot be None or blank for index {ind_attr!r}",
-                        [
-                            ob
-                            for ob in new_objs
-                            if getattr(ob, ind_attr, NO_SUCH_ATTR) is None
-                        ],
-                    )
-                if len(new_keys) < len(new_objs):
-                    raise KeyError(
-                        f"given sequence contains duplicate keys for index {ind_attr!r}"
-                    )
-                for key in new_keys:
-                    if key in ind:
-                        obj = new_keys[key]
-                        raise KeyError(
-                            f"duplicate unique key value {getattr(obj, ind_attr)!r} for index {ind_attr!r}",
-                            new_keys[key],
-                        )
-
         if self._indexes:
             for obj in new_objs:
                 self.obs.append(obj)
-                for attr, ind in self._indexes.items():
-                    obval = getattr(obj, attr, None)
-                    ind[obval] = obj
+                for ind in self._indexes.values():
+                    ind.add(obj)
         else:
             self.obs.extend(new_objs)
 
@@ -2108,7 +2093,6 @@ class Table[TableContent]:
                 kwargs_list.sort(key=self._query_attr_sort_fn)
 
             ret = self
-            NO_SUCH_ATTR = object()
             for k, v in kwargs_list:
                 if callable(v):
                     if getattr(v, "is_comparator", False):
@@ -3780,13 +3764,12 @@ class Table[TableContent]:
         Quick method to list informative table statistics
         :return: dict listing table information and statistics
         """
-        unique_indexes = set(self._uniqueIndexes)
         return {
             "len": len(self),
             "name": self.table_name,
             "fields": self._attr_names(),
             "indexes": [
-                (idx_name, self._indexes[idx_name] in unique_indexes)
+                (idx_name, self._indexes[idx_name].is_unique)
                 for idx_name in self._indexes
             ],
             "created": self.create_time,

--- a/littletable.py
+++ b/littletable.py
@@ -1976,26 +1976,23 @@ class Table[TableContent]:
     def insert_many(self, new_objs: Iterable[TableContent]) -> Self:
         """Inserts a collection of objects into the table."""
         
-        if self._indexes:
-            for obj in new_objs:
-                if isinstance(obj, dict):
-                    obj = self._wrap_dict(obj)
-                
-                try:
-                    for ind in self._indexes.values():
-                        ind.add(obj)
-                except:
-                    # Improvised rollback
-                    failing_ind = ind
-                    for ind in self._indexes.values():
-                        if ind is failing_ind:
-                            break
-                        ind.remove(obj)
-                    raise
-                
-                self.obs.append(obj)
-        else:
-            self.obs.extend(new_objs)
+        for obj in new_objs:
+            if isinstance(obj, dict):
+                obj = self._wrap_dict(obj)
+            
+            try:
+                for ind in self._indexes.values():
+                    ind.add(obj)
+            except:
+                # Improvised rollback
+                failing_ind = ind
+                for ind in self._indexes.values():
+                    if ind is failing_ind:
+                        break
+                    ind.remove(obj)
+                raise
+            
+            self.obs.append(obj)
 
         self._contents_changed()
         return self

--- a/littletable.py
+++ b/littletable.py
@@ -530,7 +530,7 @@ class _UniqueObjIndex(_ObjIndex):
         try:
             self[k] = obj
         except KeyError:
-            raise KeyError(f"duplicate unique key value {k!r} for index {self!r}", obj)
+            raise KeyError(f"duplicate unique key value {k!r} for index {self.attr!r}", obj) from None
 
     def remove(self, obj):
         k = getattr(obj, self.attr)
@@ -1962,24 +1962,27 @@ class Table[TableContent]:
         """
         return self.insert_many([obj])
 
-    def insert_many(self, it: Iterable[TableContent]) -> Self:
+    def insert_many(self, new_objs: Iterable[TableContent]) -> Self:
         """Inserts a collection of objects into the table."""
-        new_objs = it
-        new_objs, first_obj = itertools.tee(new_objs)
-        try:
-            first = next(first_obj)
-            if isinstance(first, dict):
-                # passed in a list of dicts, save as attributed objects
-                new_objs = (self._wrap_dict(obj) for obj in new_objs)
-        except StopIteration:
-            # iterator is empty, nothing to insert
-            return self
-
+        
         if self._indexes:
             for obj in new_objs:
+                if isinstance(obj, dict):
+                    obj = self._wrap_dict(obj)
+                
+                try:
+                    for ind in self._indexes.values():
+                        ind.add(obj)
+                except:
+                    # Improvised rollback
+                    failing_ind = ind
+                    for ind in self._indexes.values():
+                        if ind is failing_ind:
+                            break
+                        ind.remove(obj)
+                    raise
+                
                 self.obs.append(obj)
-                for ind in self._indexes.values():
-                    ind.add(obj)
         else:
             self.obs.extend(new_objs)
 


### PR DESCRIPTION
Cherry-picked from #9 only the core change implementing #8 and straight-up fixes.

Didn't include the changelog entries or the pyproject.toml mention of my contribution, in case that was also something you felt "overstepped the boundaries". (Although as far as I am aware, regardless of any mention, I legally retain copyright of the parts I contribute unless you give me a CLA to sign, if that is something you care about).

The question about sorting `keys()` from the previous PR remains standing. The current implementation for a non-unique index does the same as it did before (sort all, and exclude `None` altogether), while for a unique index it works around non-comparable types by comparing `id`s.

Also, I'd like to point out that I have "Allow edits by maintainers" enabled, meaning you have access to my branch to change any minor details you're unhappy with. If you don't want to do it yourself, I would prefer you asking for changes without closing the PR, as that leaves me without the option to reopen it. Notice how this PR is from the same branch as the last one, yet I had to create a different PR for what is conceptually adjustments to the original one.

I also grew inspired to create my own project providing similar functionality. I do not intend to inherit any code from this, I'm planning to write only the limited subset of features I need from the ground up. (This is informational and has no relation to the contents of the PR).